### PR TITLE
Decode and check the Firebase JWT locally

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Imports:
     shinyWidgets,
     rlang,
     purrr,
-    uuid
+    uuid,
+    jose
 Remotes: 
     github::tychobra/tychobratools
 RoxygenNote: 7.0.2

--- a/R/global_sessions_config.R
+++ b/R/global_sessions_config.R
@@ -7,16 +7,19 @@
 #' @param authorization_level either "app" or "all".  Use "app" to individually authorize users to this
 #' app.  Use "all" to give all user that have access to any of your apps access to this app.  "all" is
 #' used by our "apps_dashboard_*".
+#' @param firebase_project_id the firebase project ID
 #'
 #' @export
 #'
-global_sessions_config <- function(app_name, firebase_functions_url, conn, authorization_level = "app") {
+global_sessions_config <- function(app_name, firebase_functions_url, conn, authorization_level = "app",
+                                   firebase_project_id = NULL) {
 
   .global_sessions$config(
     app_name = app_name,
     firebase_functions_url = firebase_functions_url,
     conn = conn,
-    authorization_level = authorization_level
+    authorization_level = authorization_level,
+    firebase_project_id = firebase_project_id
   )
 
 }


### PR DESCRIPTION
We have enough information to verify the token locally. This will save a call and remove the need for the "sign_in_firebase" Cloud function.