### PR TITLE
Fixed x-axis for Unique Daily Users chart

### DIFF
--- a/R/dashboard_module.R
+++ b/R/dashboard_module.R
@@ -282,7 +282,7 @@ dashboard_module <- function(input, output, session) {
 
   output$daily_users_chart <- apexcharter::renderApexchart({
     dat <- daily_users_chart_prep()
-
+    
     ax_out <- apexcharter::apexchart() %>%
       apexcharter::ax_title(
         "Unique Daily Users",
@@ -316,6 +316,7 @@ dashboard_module <- function(input, output, session) {
         )
       ) %>%
       apexcharter::ax_xaxis(
+        type = 'datetime',
         categories = dat$date_out
       ) %>%
       apexcharter::ax_stroke(show = TRUE, curve = "straight") %>%


### PR DESCRIPTION
Changing x-axis `type` to `datetime` dynamically shows reasonable # of x-axis ticks while still allowing tooltip to show specific dates