### PR TITLE
consistent names for custom input IDs

### DIFF
--- a/R/sign_in_components.R
+++ b/R/sign_in_components.R
@@ -26,7 +26,7 @@ sign_in_js <- function(ns) {
     firebase_init(firebase_config),
     tags$script(src = "polish/js/toast_options.js"),
     tags$script(src = "https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"),
-    tags$script(src = "polish/js/auth_firebase.js?version=6"),
+    tags$script(src = "polish/js/auth_firebase.js?version=7"),
     tags$script(paste0("auth_firebase('", ns(''), "')"))
   )
 }

--- a/R/sign_in_components.R
+++ b/R/sign_in_components.R
@@ -62,7 +62,7 @@ sign_in_check_jwt <- function(jwt, session = shiny::getDefaultReactiveDomain()) 
       )
 
       if (is.null(new_user)) {
-        shinyFeedback::resetLoadingButton('submit_sign_in')
+        shinyFeedback::resetLoadingButton('sign_in_submit')
         # show unable to sign in message
         shinyFeedback::showToast('error', 'sign in error')
         stop('sign_in_module: sign in error', call. = FALSE)
@@ -74,7 +74,7 @@ sign_in_check_jwt <- function(jwt, session = shiny::getDefaultReactiveDomain()) 
       }
 
     }, error = function(e) {
-      shinyFeedback::resetLoadingButton('submit_sign_in')
+      shinyFeedback::resetLoadingButton('sign_in_submit')
       print(e)
       shinyWidgets::sendSweetAlert(
         session,

--- a/R/sign_in_module.R
+++ b/R/sign_in_module.R
@@ -35,17 +35,17 @@ sign_in_module_ui <- function(
     )
   )
 
-  sign_in_password <- div(
-    id = ns("sign_in_password"),
+  sign_in_password_ui <- div(
+    id = ns("sign_in_password_ui"),
     div(
       class = "form-group",
       style = "width: 100%;",
       tags$label(
         tagList(icon("unlock-alt"), "password"),
-        `for` = "password"
+        `for` = "sign_in_password"
       ),
       tags$input(
-        id = ns("password"),
+        id = ns("sign_in_password"),
         type = "password",
         class = "form-control",
         value = ""
@@ -53,7 +53,7 @@ sign_in_module_ui <- function(
     ),
     br(),
     shinyFeedback::loadingButton(
-      ns("submit_sign_in"),
+      ns("sign_in_submit"),
       label = "Sign In",
       class = "btn btn-primary btn-lg text-center",
       style = "width: 100%",
@@ -109,7 +109,7 @@ sign_in_module_ui <- function(
     div(
       style = "text-align: center;",
       shinyFeedback::loadingButton(
-        ns("submit_register"),
+        ns("register_submit"),
         label = "Register",
         class = "btn btn-primary btn-lg",
         style = "width: 100%;",
@@ -131,7 +131,7 @@ sign_in_module_ui <- function(
       ),
       tags$br(),
       email_input(
-        inputId = ns("email"),
+        inputId = ns("sign_in_email"),
         label = tagList(icon("envelope"), "email"),
         value = ""
       ),
@@ -140,9 +140,9 @@ sign_in_module_ui <- function(
     tags$div(
       id = ns("sign_in_panel_bottom"),
       if (isTRUE(.global_sessions$is_invite_required)) {
-        tagList(continue_sign_in, shinyjs::hidden(sign_in_password))
+        tagList(continue_sign_in, shinyjs::hidden(sign_in_password_ui))
       } else {
-        sign_in_password
+        sign_in_password_ui
       },
       div(
         style = "text-align: center;",
@@ -175,7 +175,7 @@ sign_in_module_ui <- function(
       ),
       tags$br(),
       email_input(
-        inputId = ns("email_register"),
+        inputId = ns("register_email"),
         label = tagList(icon("envelope"), "email"),
         value = ""
       ),
@@ -228,7 +228,7 @@ sign_in_module_ui <- function(
       class = "auth_panel",
       ui_out
     ),
-    tags$script(src = "polish/js/auth_keypress.js"),
+    tags$script(src = "polish/js/auth_keypress.js?version=4"),
     tags$script(paste0("auth_keypress('", ns(''), "')")),
     sign_in_js(ns)
   )
@@ -279,7 +279,7 @@ sign_in_module <- function(input, output, session) {
 
   shiny::observeEvent(input$submit_continue_sign_in, {
 
-    email <- tolower(input$email)
+    email <- tolower(input$sign_in_email)
 
     # check user invite
     invite <- NULL
@@ -330,7 +330,7 @@ sign_in_module <- function(input, output, session) {
 
 
   observeEvent(input$check_registered_res, {
-    hold_email <- tolower(input$email)
+    hold_email <- tolower(input$sign_in_email)
 
     is_registered <- input$check_registered_res
 
@@ -340,14 +340,14 @@ sign_in_module <- function(input, output, session) {
       shinyjs::hide("submit_continue_sign_in")
 
       shinyjs::show(
-        "sign_in_password",
+        "sign_in_password_ui",
         anim = TRUE
       )
 
       # NEED to sleep this exact amount to allow animation (above) to show w/o bug
       Sys.sleep(.25)
 
-      shinyjs::runjs(paste0("$('#", ns('password'), "').focus()"))
+      shinyjs::runjs(paste0("$('#", ns('sign_in_password'), "').focus()"))
 
     } else if (isFALSE(is_registered)) {
 
@@ -356,7 +356,7 @@ sign_in_module <- function(input, output, session) {
 
       shiny::updateTextInput(
         session,
-        "email_register",
+        "register_email",
         value = hold_email
       )
 
@@ -410,7 +410,7 @@ sign_in_module <- function(input, output, session) {
 
   shiny::observeEvent(submit_continue_register_rv(), {
 
-    email <- tolower(input$email_register)
+    email <- tolower(input$register_email)
 
     invite <- NULL
     tryCatch({

--- a/R/sign_in_module_2.R
+++ b/R/sign_in_module_2.R
@@ -19,24 +19,24 @@
 sign_in_module_2_ui <- function(id) {
   ns <- shiny::NS(id)
 
-  sign_in_password <- div(
-    id = ns("sign_in_password"),
+  sign_in_password_ui <- div(
+    id = ns("sign_in_password_ui"),
     div(
       class = "form-group",
       style = "width: 100%;",
       tags$label(
         tagList(icon("unlock-alt"), "password"),
-        `for` = "password"
+        `for` = "sign_in_password"
       ),
       tags$input(
-        id = ns("password"),
+        id = ns("sign_in_password"),
         type = "password",
         class = "form-control",
         value = ""
       )
     ),
     shinyFeedback::loadingButton(
-      ns("submit_sign_in"),
+      ns("sign_in_submit"),
       label = "Sign In",
       class = "btn btn-primary btn-lg text-center",
       style = "width: 100%",
@@ -60,7 +60,7 @@ sign_in_module_2_ui <- function(id) {
     id = ns("email_ui"),
     tags$br(),
     email_input(
-      inputId = ns("email"),
+      inputId = ns("sign_in_email"),
       label = tagList(icon("envelope"), "email"),
       value = "",
       width = "100%"
@@ -68,9 +68,9 @@ sign_in_module_2_ui <- function(id) {
     tags$div(
       id = ns("sign_in_panel_bottom"),
       if (isTRUE(.global_sessions$is_invite_required)) {
-        tagList(continue_sign_in, shinyjs::hidden(sign_in_password))
+        tagList(continue_sign_in, shinyjs::hidden(sign_in_password_ui))
       } else {
-        sign_in_password
+        sign_in_password_ui
       },
       div(
         style = "text-align: center;",
@@ -128,7 +128,7 @@ sign_in_module_2_ui <- function(id) {
     div(
       style = "text-align: center;",
       shinyFeedback::loadingButton(
-        ns("submit_register"),
+        ns("register_submit"),
         label = "Register",
         class = "btn btn-primary btn-lg",
         style = "width: 100%;",
@@ -144,7 +144,7 @@ sign_in_module_2_ui <- function(id) {
   register_ui <- div(
     br(),
     email_input(
-      inputId = ns("email_register"),
+      inputId = ns("register_email"),
       label = tagList(icon("envelope"), "email"),
       value = "",
       width = "100%"
@@ -206,7 +206,7 @@ sign_in_module_2_ui <- function(id) {
   htmltools::tagList(
     shinyjs::useShinyjs(),
     sign_in_ui,
-    tags$script(src = "polish/js/auth_keypress_2.js"),
+    tags$script(src = "polish/js/auth_keypress_2.js?version=2"),
     tags$script(paste0("auth_keypress('", ns(''), "')")),
     sign_in_js(ns)
   )
@@ -251,7 +251,7 @@ sign_in_module_2 <- function(input, output, session) {
 
   shiny::observeEvent(input$submit_continue_sign_in, {
 
-    email <- tolower(input$email)
+    email <- tolower(input$sign_in_email)
 
     # check user invite
     invite <- NULL
@@ -303,7 +303,7 @@ sign_in_module_2 <- function(input, output, session) {
 
 
   observeEvent(input$check_registered_res, {
-    hold_email <- tolower(input$email)
+    hold_email <- tolower(input$sign_in_email)
 
     is_registered <- input$check_registered_res
 
@@ -313,14 +313,14 @@ sign_in_module_2 <- function(input, output, session) {
       shinyjs::hide("submit_continue_sign_in")
 
       shinyjs::show(
-        "sign_in_password",
+        "sign_in_password_ui",
         anim = TRUE
       )
 
       # NEED to sleep this exact amount to allow animation (above) to show w/o bug
       Sys.sleep(.25)
 
-      shinyjs::runjs(paste0("$('#", ns('password'), "').focus()"))
+      shinyjs::runjs(paste0("$('#", ns('sign_in_password'), "').focus()"))
     } else if (isFALSE(is_registered)) {
 
       shiny::updateTabsetPanel(
@@ -331,7 +331,7 @@ sign_in_module_2 <- function(input, output, session) {
 
       shiny::updateTextInput(
         session,
-        "email_register",
+        "register_email",
         value = hold_email
       )
 
@@ -368,7 +368,7 @@ sign_in_module_2 <- function(input, output, session) {
 
   shiny::observeEvent(submit_continue_register_rv(), {
 
-    email <- tolower(input$email_register)
+    email <- tolower(input$register_email)
 
     invite <- NULL
     tryCatch({

--- a/inst/assets/js/auth_firebase.js
+++ b/inst/assets/js/auth_firebase.js
@@ -25,14 +25,14 @@ var auth_firebase = function auth_firebase(ns_prefix) {
     });
   };
 
-  $(document).on("click", "#".concat(ns_prefix, "submit_register"), function () {
-    var email = $("#".concat(ns_prefix, "email_register")).val().toLowerCase();
+  $(document).on("click", "#".concat(ns_prefix, "register_submit"), function () {
+    var email = $("#".concat(ns_prefix, "register_email")).val().toLowerCase();
     var password = $("#".concat(ns_prefix, "register_password")).val();
     var password_2 = $("#".concat(ns_prefix, "register_password_verify")).val();
 
     if (password !== password_2) {
       // Event to reset Register loading button from loading state back to ready state
-      loadingButtons.resetLoading("".concat(ns_prefix, "submit_register"));
+      loadingButtons.resetLoading("".concat(ns_prefix, "register_submit"));
       toastr.error("The passwords do not match", null, toast_options);
       console.log("the passwords do not match");
       return;
@@ -42,23 +42,23 @@ var auth_firebase = function auth_firebase(ns_prefix) {
       // send verification email
       return userCredential.user.sendEmailVerification()["catch"](function (error) {
         console.error("Error sending email verification", error);
-        loadingButtons.resetLoading("".concat(ns_prefix, "submit_register"));
+        loadingButtons.resetLoading("".concat(ns_prefix, "register_submit"));
       });
     }).then(function () {
       return sign_in(email, password)["catch"](function (error) {
         toastr.error("Sign in Error: ".concat(error.message), null, toast_options);
         console.log("error: ", error);
-        loadingButtons.resetLoading("".concat(ns_prefix, "submit_sign_in"));
+        loadingButtons.resetLoading("".concat(ns_prefix, "sign_in_submit"));
       });
     })["catch"](function (error) {
       toastr.error("" + error, null, toast_options);
       console.log("error registering user");
       console.log(error);
-      loadingButtons.resetLoading("".concat(ns_prefix, "submit_register"));
+      loadingButtons.resetLoading("".concat(ns_prefix, "register_submit"));
     });
   });
   $(document).on("click", "#".concat(ns_prefix, "reset_password"), function () {
-    var email = $("#".concat(ns_prefix, "email")).val().toLowerCase();
+    var email = $("#".concat(ns_prefix, "sign_in_email")).val().toLowerCase();
     auth.sendPasswordResetEmail(email).then(function () {
       console.log("Password reset email sent to ".concat(email));
       toastr.success("Password reset email sent to ".concat(email), null, toast_options);
@@ -67,12 +67,12 @@ var auth_firebase = function auth_firebase(ns_prefix) {
       console.log("error resetting email: ", error);
     });
   });
-  $(document).on("click", "#".concat(ns_prefix, "submit_sign_in"), function () {
-    var email = $("#".concat(ns_prefix, "email")).val().toLowerCase();
-    var password = $("#".concat(ns_prefix, "password")).val();
+  $(document).on("click", "#".concat(ns_prefix, "sign_in_submit"), function () {
+    var email = $("#".concat(ns_prefix, "sign_in_email")).val().toLowerCase();
+    var password = $("#".concat(ns_prefix, "sign_in_password")).val();
     sign_in(email, password)["catch"](function (error) {
       // Event to reset Sign In loading button
-      loadingButtons.resetLoading("".concat(ns_prefix, "submit_sign_in"));
+      loadingButtons.resetLoading("".concat(ns_prefix, "sign_in_submit"));
       toastr.error("Sign in Error: ".concat(error.message), null, toast_options);
       console.log("error: ", error);
     });

--- a/inst/assets/js/auth_keypress.js
+++ b/inst/assets/js/auth_keypress.js
@@ -1,38 +1,37 @@
 "use strict";
 
 var auth_keypress = function auth_keypress(ns_prefix) {
-  $("#".concat(ns_prefix, "email")).on("keypress", function (e) {
+  $("#".concat(ns_prefix, "sign_in_email")).on("keypress", function (e) {
     if (e.which == 13) {
-      if ($("#".concat(ns_prefix, "sign_in_panel_top")).is(":visible")) {
-        // user is on sign in page
-        if ($("#".concat(ns_prefix, "submit_continue_sign_in")).is(":visible")) {
-          $("#".concat(ns_prefix, "submit_continue_sign_in")).click();
-        } else {
-          $("#".concat(ns_prefix, "submit_sign_in")).click();
-        }
+      if ($("#".concat(ns_prefix, "submit_continue_sign_in")).is(":visible")) {
+        $("#".concat(ns_prefix, "submit_continue_sign_in")).click();
       } else {
-        // user is on register page
-        if ($("#".concat(ns_prefix, "submit_continue_register")).is(":visible")) {
-          $("#".concat(ns_prefix, "submit_continue_register")).click();
-        } else {
-          $("#".concat(ns_prefix, "submit_register")).click();
-        }
+        $("#".concat(ns_prefix, "sign_in_submit")).click();
       }
     }
   });
-  $("#".concat(ns_prefix, "password")).on('keypress', function (e) {
+  $("#".concat(ns_prefix, "register_email")).on("keypress", function (e) {
     if (e.which == 13) {
-      $("#".concat(ns_prefix, "submit_sign_in")).click();
+      if ($("#".concat(ns_prefix, "submit_continue_register")).is(":visible")) {
+        $("#".concat(ns_prefix, "submit_continue_register")).click();
+      } else {
+        $("#".concat(ns_prefix, "register_submit")).click();
+      }
+    }
+  });
+  $("#".concat(ns_prefix, "sign_in_password")).on('keypress', function (e) {
+    if (e.which == 13) {
+      $("#".concat(ns_prefix, "sign_in_submit")).click();
     }
   });
   $("#".concat(ns_prefix, "register_password")).on('keypress', function (e) {
     if (e.which == 13) {
-      $("#".concat(ns_prefix, "submit_register")).click();
+      $("#".concat(ns_prefix, "register_submit")).click();
     }
   });
   $("#".concat(ns_prefix, "register_password_verify")).on('keypress', function (e) {
     if (e.which == 13) {
-      $("#".concat(ns_prefix, "submit_register")).click();
+      $("#".concat(ns_prefix, "register_submit")).click();
     }
   });
 };

--- a/inst/assets/js/auth_keypress_2.js
+++ b/inst/assets/js/auth_keypress_2.js
@@ -1,37 +1,37 @@
 "use strict";
 
 var auth_keypress = function auth_keypress(ns_prefix) {
-  $("#".concat(ns_prefix, "email")).on("keypress", function (e) {
+  $("#".concat(ns_prefix, "sign_in_email")).on("keypress", function (e) {
     if (e.which == 13) {
       if ($("#".concat(ns_prefix, "submit_continue_sign_in")).is(":visible")) {
         $("#".concat(ns_prefix, "submit_continue_sign_in")).click();
       } else {
-        $("#".concat(ns_prefix, "submit_sign_in")).click();
+        $("#".concat(ns_prefix, "sign_in_submit")).click();
       }
     }
   });
-  $("#".concat(ns_prefix, "email_register")).on("keypress", function (e) {
+  $("#".concat(ns_prefix, "register_email")).on("keypress", function (e) {
     if (e.which == 13) {
       if ($("#".concat(ns_prefix, "submit_continue_register")).is(":visible")) {
         $("#".concat(ns_prefix, "submit_continue_register")).click();
       } else {
-        $("#".concat(ns_prefix, "submit_register")).click();
+        $("#".concat(ns_prefix, "register_submit")).click();
       }
     }
   });
-  $("#".concat(ns_prefix, "password")).on('keypress', function (e) {
+  $("#".concat(ns_prefix, "sign_in_password")).on('keypress', function (e) {
     if (e.which == 13) {
-      $("#".concat(ns_prefix, "submit_sign_in")).click();
+      $("#".concat(ns_prefix, "sign_in_submit")).click();
     }
   });
   $("#".concat(ns_prefix, "register_password")).on('keypress', function (e) {
     if (e.which == 13) {
-      $("#".concat(ns_prefix, "submit_register")).click();
+      $("#".concat(ns_prefix, "register_submit")).click();
     }
   });
   $("#".concat(ns_prefix, "register_password_verify")).on('keypress', function (e) {
     if (e.which == 13) {
-      $("#".concat(ns_prefix, "submit_register")).click();
+      $("#".concat(ns_prefix, "register_submit")).click();
     }
   });
 };

--- a/srcjs/src/auth_firebase.js
+++ b/srcjs/src/auth_firebase.js
@@ -36,14 +36,14 @@ const auth_firebase = (ns_prefix) => {
     })
   }
 
-  $(document).on("click", `#${ns_prefix}submit_register`, () => {
-    const email = $(`#${ns_prefix}email_register`).val().toLowerCase()
+  $(document).on("click", `#${ns_prefix}register_submit`, () => {
+    const email = $(`#${ns_prefix}register_email`).val().toLowerCase()
     const password = $(`#${ns_prefix}register_password`).val()
     const password_2 = $(`#${ns_prefix}register_password_verify`).val()
 
     if (password !== password_2) {
       // Event to reset Register loading button from loading state back to ready state
-      loadingButtons.resetLoading(`${ns_prefix}submit_register`);
+      loadingButtons.resetLoading(`${ns_prefix}register_submit`);
 
       toastr.error("The passwords do not match", null, toast_options)
       console.log("the passwords do not match")
@@ -56,7 +56,7 @@ const auth_firebase = (ns_prefix) => {
       // send verification email
       return userCredential.user.sendEmailVerification().catch(error => {
         console.error("Error sending email verification", error)
-        loadingButtons.resetLoading(`${ns_prefix}submit_register`);
+        loadingButtons.resetLoading(`${ns_prefix}register_submit`);
       })
 
 
@@ -65,21 +65,21 @@ const auth_firebase = (ns_prefix) => {
       return sign_in(email, password).catch(error => {
         toastr.error(`Sign in Error: ${error.message}`, null, toast_options)
         console.log("error: ", error)
-        loadingButtons.resetLoading(`${ns_prefix}submit_sign_in`);
+        loadingButtons.resetLoading(`${ns_prefix}sign_in_submit`);
       })
 
     }).catch((error) => {
       toastr.error("" + error, null, toast_options)
       console.log("error registering user")
       console.log(error)
-      loadingButtons.resetLoading(`${ns_prefix}submit_register`);
+      loadingButtons.resetLoading(`${ns_prefix}register_submit`);
     })
 
   })
 
 
   $(document).on("click", `#${ns_prefix}reset_password`, () => {
-    const email = $(`#${ns_prefix}email`).val().toLowerCase()
+    const email = $(`#${ns_prefix}sign_in_email`).val().toLowerCase()
 
     auth.sendPasswordResetEmail(email).then(() => {
       console.log(`Password reset email sent to ${email}`)
@@ -90,15 +90,15 @@ const auth_firebase = (ns_prefix) => {
     })
   })
 
-  $(document).on("click", `#${ns_prefix}submit_sign_in`, () => {
+  $(document).on("click", `#${ns_prefix}sign_in_submit`, () => {
 
-    const email = $(`#${ns_prefix}email`).val().toLowerCase()
-    const password = $(`#${ns_prefix}password`).val()
+    const email = $(`#${ns_prefix}sign_in_email`).val().toLowerCase()
+    const password = $(`#${ns_prefix}sign_in_password`).val()
 
     sign_in(email, password).catch(error => {
 
       // Event to reset Sign In loading button
-      loadingButtons.resetLoading(`${ns_prefix}submit_sign_in`);
+      loadingButtons.resetLoading(`${ns_prefix}sign_in_submit`);
       toastr.error(`Sign in Error: ${error.message}`, null, toast_options)
       console.log("error: ", error)
     })

--- a/srcjs/src/auth_keypress.js
+++ b/srcjs/src/auth_keypress.js
@@ -7,56 +7,56 @@
 const auth_keypress = (ns_prefix) => {
 
 
-  $(`#${ns_prefix}email`).on("keypress", e => {
+  $(`#${ns_prefix}sign_in_email`).on("keypress", e => {
 
     if(e.which == 13) {
 
-      if ($(`#${ns_prefix}sign_in_panel_top`).is(":visible")) {
-        // user is on sign in page
-        if ($(`#${ns_prefix}submit_continue_sign_in`).is(":visible")) {
 
-          $(`#${ns_prefix}submit_continue_sign_in`).click()
+      if ($(`#${ns_prefix}submit_continue_sign_in`).is(":visible")) {
 
-        } else {
+        $(`#${ns_prefix}submit_continue_sign_in`).click()
 
-          $(`#${ns_prefix}submit_sign_in`).click()
-
-        }
       } else {
-        // user is on register page
 
-        if ($(`#${ns_prefix}submit_continue_register`).is(":visible")) {
-
-          $(`#${ns_prefix}submit_continue_register`).click()
-
-        } else {
-
-
-          $(`#${ns_prefix}submit_register`).click()
-
-        }
+        $(`#${ns_prefix}sign_in_submit`).click()
 
       }
-
     }
   })
 
-  $(`#${ns_prefix}password`).on('keypress', e => {
+  $(`#${ns_prefix}register_email`).on("keypress", e => {
+
     if(e.which == 13) {
-      $(`#${ns_prefix}submit_sign_in`).click()
+      if ($(`#${ns_prefix}submit_continue_register`).is(":visible")) {
+
+        $(`#${ns_prefix}submit_continue_register`).click()
+
+      } else {
+
+
+        $(`#${ns_prefix}register_submit`).click()
+
+      }
+    }
+  })
+
+
+  $(`#${ns_prefix}sign_in_password`).on('keypress', e => {
+    if(e.which == 13) {
+      $(`#${ns_prefix}sign_in_submit`).click()
     }
   })
 
 
   $(`#${ns_prefix}register_password`).on('keypress', e => {
     if(e.which == 13) {
-      $(`#${ns_prefix}submit_register`).click()
+      $(`#${ns_prefix}register_submit`).click()
     }
   })
 
   $(`#${ns_prefix}register_password_verify`).on('keypress', e => {
     if(e.which == 13) {
-      $(`#${ns_prefix}submit_register`).click()
+      $(`#${ns_prefix}register_submit`).click()
     }
   })
 

--- a/srcjs/src/auth_keypress_2.js
+++ b/srcjs/src/auth_keypress_2.js
@@ -2,53 +2,53 @@
 const auth_keypress = (ns_prefix) => {
 
 
-  $(`#${ns_prefix}email`).on("keypress", e => {
+  $(`#${ns_prefix}sign_in_email`).on("keypress", e => {
 
     if(e.which == 13) {
-      
+
       if ($(`#${ns_prefix}submit_continue_sign_in`).is(":visible")) {
 
         $(`#${ns_prefix}submit_continue_sign_in`).click()
 
       } else {
 
-        $(`#${ns_prefix}submit_sign_in`).click()
+        $(`#${ns_prefix}sign_in_submit`).click()
 
       }
     }
   })
-  
-  $(`#${ns_prefix}email_register`).on("keypress", e => {
-    
+
+  $(`#${ns_prefix}register_email`).on("keypress", e => {
+
     if (e.which == 13) {
       if ($(`#${ns_prefix}submit_continue_register`).is(":visible")) {
-        
+
         $(`#${ns_prefix}submit_continue_register`).click()
-        
+
       } else {
-        
-        $(`#${ns_prefix}submit_register`).click()
-        
+
+        $(`#${ns_prefix}register_submit`).click()
+
       }
     }
   })
 
-  $(`#${ns_prefix}password`).on('keypress', e => {
+  $(`#${ns_prefix}sign_in_password`).on('keypress', e => {
     if(e.which == 13) {
-      $(`#${ns_prefix}submit_sign_in`).click()
+      $(`#${ns_prefix}sign_in_submit`).click()
     }
   })
 
 
   $(`#${ns_prefix}register_password`).on('keypress', e => {
     if(e.which == 13) {
-      $(`#${ns_prefix}submit_register`).click()
+      $(`#${ns_prefix}register_submit`).click()
     }
   })
 
   $(`#${ns_prefix}register_password_verify`).on('keypress', e => {
     if(e.which == 13) {
-      $(`#${ns_prefix}submit_register`).click()
+      $(`#${ns_prefix}register_submit`).click()
     }
   })
 

--- a/vignettes/create_custom_sign_in_pages.Rmd
+++ b/vignettes/create_custom_sign_in_pages.Rmd
@@ -36,14 +36,14 @@ sign_in_check_jwt()
 
 Behind the scenes, the `sign_in_module()` and `sign_in_no_invite_module()` use the 2 above functions to build their UI and server functionality.  To fully customize your sign in pages, you can create your own shiny module that uses these functions. To create your own fully cuatomized sign in module, include inputs with the following name-spaced ids:
 
-- "email"
-- "password"
-- "submit_sign_in"
+- "sign_in_email"
+- "sign_in_password"
+- "sign_in_submit"
 
-- "email_register"
+- "register_email"
 - "register_password"
 - "register_password_verify"
-- "submit_register"
+- "register_submit"
 
 You can create `shiny::textInputs`, `shiny::passwordInput`s, and `shiny::actionButton`s with the above IDs, or you can use the `email_input` and `password_input` functions available with `polished`;  As long as the ID of the inputs match up with the above input IDs, then the JavaScript available with `sign_in_js()` and the server logic in `sign_in_check_jwt()` will be able to handle the sign in and registration.  See the example below:
 
@@ -61,17 +61,16 @@ my_custom_sign_in_module_ui <- function(id) {
     shinyjs::useShinyjs(),
     # your custom sign in inputs
     
-    # both the register and sign in pages use the same email input
-    email_input(
-      ns("email")
-    ),
     div(
       id = ns("sign_in_page"),
+      email_input(
+        ns("sign_in_email")
+      ),
       password_input(
-        ns("password")
+        ns("sign_in_password")
       ),
       actionButton(
-        ns("submit_sign_in"),
+        ns("sign_in_submit"),
         "Sign In"
       ),
       actionLink(
@@ -91,7 +90,7 @@ my_custom_sign_in_module_ui <- function(id) {
           ns("register_password_verify")
         ),
         actionButton(
-          ns("submit_register"),
+          ns("register_submit"),
           "Register"
         ),
         actionLink(


### PR DESCRIPTION
I updated the required input id names to use a consistent format.  The IDs are now:

- "sign_in_email"
- "sign_in_password"
- "sign_in_submit"

- "register_email"
- "register_password"
- "register_password_verify"
- "register_submit"

These IDs are used in the sign in modules and 3 of the JavaScript files.  Please review to make sure that I did not miss updating any of the IDs. 