### PR TITLE
Iframe cookie

### DIFF
--- a/R/sign_in_components.R
+++ b/R/sign_in_components.R
@@ -25,7 +25,7 @@ sign_in_js <- function(ns) {
     firebase_deps <- htmltools::tagList(
       firebase_dependencies(),
       firebase_init(firebase_config),
-      tags$script(src = "polish/js/auth_firebase.js?version=3"),
+      tags$script(src = "polish/js/auth_firebase.js?version=4"),
       tags$script(paste0("auth_firebase('", ns(''), "')"))
     )
   }
@@ -35,7 +35,7 @@ sign_in_js <- function(ns) {
     tags$script(src = "polish/js/toast_options.js"),
     tags$script(src = "https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"),
     firebase_deps,
-    tags$script(src = "polish/js/auth_main.js?version=3"),
+    tags$script(src = "polish/js/auth_main.js?version=4"),
     tags$script(paste0("auth_main('", ns(''), "')"))
   )
 }

--- a/inst/assets/js/auth_firebase.js
+++ b/inst/assets/js/auth_firebase.js
@@ -9,8 +9,8 @@ var auth_firebase = function auth_firebase(ns_prefix) {
 
   if (location.protocol === 'https:') {
     // add cookie options that browsers are starting to require to allow you to
-    // use cookies within iframes.
-    cookie_options.simeSite = 'none';
+    // use cookies within iframes.  Only works when app is running on https.
+    cookie_options.sameSite = 'none';
     cookie_options.secure = true;
   }
 

--- a/inst/assets/js/auth_firebase.js
+++ b/inst/assets/js/auth_firebase.js
@@ -7,9 +7,11 @@ var auth_firebase = function auth_firebase(ns_prefix) {
     return user.getIdToken(true).then(function (firebase_token) {
       var polished_cookie = "p" + Math.random();
       Cookies.set('polished', polished_cookie, {
-        expires: 365
-      } // set cookie to expire in 1 year
-      );
+        expires: 365,
+        // set cookie to expire in 1 year
+        sameSite: 'none',
+        secure: true
+      });
       Shiny.setInputValue("".concat(ns_prefix, "check_jwt"), {
         jwt: firebase_token,
         cookie: polished_cookie

--- a/inst/assets/js/auth_firebase.js
+++ b/inst/assets/js/auth_firebase.js
@@ -3,15 +3,21 @@
 var auth = firebase.auth();
 
 var auth_firebase = function auth_firebase(ns_prefix) {
+  var cookie_options = {
+    expires: 365
+  }; // set cookie to expire in 1 year
+
+  if (location.protocol === 'https:') {
+    // add cookie options that browsers are starting to require to allow you to
+    // use cookies within iframes.
+    cookie_options.simeSite = 'none';
+    cookie_options.secure = true;
+  }
+
   var send_token_to_shiny = function send_token_to_shiny(user) {
     return user.getIdToken(true).then(function (firebase_token) {
       var polished_cookie = "p" + Math.random();
-      Cookies.set('polished', polished_cookie, {
-        expires: 365,
-        // set cookie to expire in 1 year
-        sameSite: 'none',
-        secure: true
-      });
+      Cookies.set('polished', polished_cookie, cookie_options);
       Shiny.setInputValue("".concat(ns_prefix, "check_jwt"), {
         jwt: firebase_token,
         cookie: polished_cookie

--- a/inst/assets/js/auth_main.js
+++ b/inst/assets/js/auth_main.js
@@ -1,14 +1,20 @@
 "use strict";
 
 var auth_main = function auth_main(ns_prefix) {
+  var cookie_options = {
+    expires: 365
+  }; // set cookie to expire in 1 year
+
+  if (location.protocol === 'https:') {
+    // add cookie options that browsers are starting to require to allow you to
+    // use cookies within iframes.
+    cookie_options.simeSite = 'none';
+    cookie_options.secure = true;
+  }
+
   var sign_in = function sign_in(email, password) {
     var polished_cookie = "p" + Math.random();
-    Cookies.set('polished', polished_cookie, {
-      expires: 365,
-      // set cookie to expire in 1 year
-      sameSite: 'none',
-      secure: true
-    });
+    Cookies.set('polished', polished_cookie, cookie_options);
     Shiny.setInputValue("".concat(ns_prefix, "check_jwt"), {
       email: email,
       password: password,

--- a/inst/assets/js/auth_main.js
+++ b/inst/assets/js/auth_main.js
@@ -4,9 +4,11 @@ var auth_main = function auth_main(ns_prefix) {
   var sign_in = function sign_in(email, password) {
     var polished_cookie = "p" + Math.random();
     Cookies.set('polished', polished_cookie, {
-      expires: 365
-    } // set cookie to expire in 1 year
-    );
+      expires: 365,
+      // set cookie to expire in 1 year
+      sameSite: 'none',
+      secure: true
+    });
     Shiny.setInputValue("".concat(ns_prefix, "check_jwt"), {
       email: email,
       password: password,

--- a/inst/assets/js/auth_main.js
+++ b/inst/assets/js/auth_main.js
@@ -7,8 +7,8 @@ var auth_main = function auth_main(ns_prefix) {
 
   if (location.protocol === 'https:') {
     // add cookie options that browsers are starting to require to allow you to
-    // use cookies within iframes.
-    cookie_options.simeSite = 'none';
+    // use cookies within iframes. Only works when app is running on https.
+    cookie_options.sameSite = 'none';
     cookie_options.secure = true;
   }
 

--- a/srcjs/src/auth_firebase.js
+++ b/srcjs/src/auth_firebase.js
@@ -3,6 +3,14 @@ const auth = firebase.auth()
 
 const auth_firebase = (ns_prefix) => {
 
+  let cookie_options = {expires: 365} // set cookie to expire in 1 year
+  if (location.protocol === 'https:') {
+    // add cookie options that browsers are starting to require to allow you to
+    // use cookies within iframes.
+    cookie_options.simeSite = 'none'
+    cookie_options.secure = true
+  }
+
   const send_token_to_shiny = (user) => {
 
     return user.getIdToken(true).then(firebase_token => {
@@ -13,10 +21,7 @@ const auth_firebase = (ns_prefix) => {
       Cookies.set(
         'polished',
         polished_cookie,
-        { expires: 365, // set cookie to expire in 1 year
-          sameSite: 'none',
-          secure: true
-        }
+        cookie_options
       )
 
       Shiny.setInputValue(`${ns_prefix}check_jwt`, {

--- a/srcjs/src/auth_firebase.js
+++ b/srcjs/src/auth_firebase.js
@@ -6,8 +6,8 @@ const auth_firebase = (ns_prefix) => {
   let cookie_options = {expires: 365} // set cookie to expire in 1 year
   if (location.protocol === 'https:') {
     // add cookie options that browsers are starting to require to allow you to
-    // use cookies within iframes.
-    cookie_options.simeSite = 'none'
+    // use cookies within iframes.  Only works when app is running on https.
+    cookie_options.sameSite = 'none'
     cookie_options.secure = true
   }
 

--- a/srcjs/src/auth_firebase.js
+++ b/srcjs/src/auth_firebase.js
@@ -13,7 +13,10 @@ const auth_firebase = (ns_prefix) => {
       Cookies.set(
         'polished',
         polished_cookie,
-        { expires: 365 } // set cookie to expire in 1 year
+        { expires: 365, // set cookie to expire in 1 year
+          sameSite: 'none',
+          secure: true
+        }
       )
 
       Shiny.setInputValue(`${ns_prefix}check_jwt`, {

--- a/srcjs/src/auth_main.js
+++ b/srcjs/src/auth_main.js
@@ -8,7 +8,10 @@ const auth_main = (ns_prefix) => {
     Cookies.set(
       'polished',
       polished_cookie,
-      { expires: 365 } // set cookie to expire in 1 year
+      { expires: 365, // set cookie to expire in 1 year
+        sameSite: 'none',
+        secure: true
+      }
     )
 
     Shiny.setInputValue(`${ns_prefix}check_jwt`, {

--- a/srcjs/src/auth_main.js
+++ b/srcjs/src/auth_main.js
@@ -4,8 +4,8 @@ const auth_main = (ns_prefix) => {
   let cookie_options = {expires: 365} // set cookie to expire in 1 year
   if (location.protocol === 'https:') {
     // add cookie options that browsers are starting to require to allow you to
-    // use cookies within iframes.
-    cookie_options.simeSite = 'none'
+    // use cookies within iframes. Only works when app is running on https.
+    cookie_options.sameSite = 'none'
     cookie_options.secure = true
   }
 

--- a/srcjs/src/auth_main.js
+++ b/srcjs/src/auth_main.js
@@ -1,6 +1,14 @@
 
 const auth_main = (ns_prefix) => {
 
+  let cookie_options = {expires: 365} // set cookie to expire in 1 year
+  if (location.protocol === 'https:') {
+    // add cookie options that browsers are starting to require to allow you to
+    // use cookies within iframes.
+    cookie_options.simeSite = 'none'
+    cookie_options.secure = true
+  }
+
   const sign_in = (email, password) => {
 
     const polished_cookie = "p" + Math.random()
@@ -8,10 +16,7 @@ const auth_main = (ns_prefix) => {
     Cookies.set(
       'polished',
       polished_cookie,
-      { expires: 365, // set cookie to expire in 1 year
-        sameSite: 'none',
-        secure: true
-      }
+      cookie_options
     )
 
     Shiny.setInputValue(`${ns_prefix}check_jwt`, {


### PR DESCRIPTION
Change cookie options based on whether or not the Shiny app is served over https.  These 2 cookie options:

- sameSite: 'none'
- secure: true

allow for cookies to work in an iframe. This allows for polished authentication to work in an iframe on a different domain than the shiny app.  Resolves #115

Tested by deploying the app to shinyapps.io and then accessing it though an iframe in Chrome from localhost and from an https site.  Both iframes (http and https) now work with polished auth.