### PR TITLE
Fix get_api_key

### DIFF
--- a/R/api_00.R
+++ b/R/api_00.R
@@ -93,10 +93,7 @@ get_api_key = function() {
   current_polished_options <- getOption("polished")
   api_key <- current_polished_options$api_key
   if (is.null(api_key)) {
-    api_key <- Sys.getenv("POLISHED_API_KEY", unset = NA)
-    if (is.na(api_key)) {
-      api_key <- NULL
-    }
+    api_key <- Sys.getenv("POLISHED_API_KEY", unset = NA_character_)
   }
   api_key
 }


### PR DESCRIPTION
If `POLISHED_API_KEY` unset & not provided in API wrapper functions, this PR keeps the returned value of `get_api_key` as a character (`NA_character`) for correct wrapper function errors. Otherwise, an `httr::authenticate` error is returned instead of `Account not found for provided API key`