### PR TITLE
Better diagnostics in dir_copy()

### DIFF
--- a/R/deploy_app.R
+++ b/R/deploy_app.R
@@ -362,10 +362,9 @@ dir_copy <- function(from, to, overwrite = TRUE, all.files = TRUE,
   if (!all(res)) {
     # The copy failed; we should clean up after ourselves and return an error
     unlink(to, recursive = TRUE)
-    message( paste( files.from ) )
-    message( paste( files.to ) )
-    message( paste( res ) )
-    stop("Could not copy all files from directory '", from, "' to directory '", to, "'.")
+    message("Could not copy these files from directory '", from, "' to directory '", to, "':")
+    paste( files.from[ res==FALSE ], collate="\n" )
+    stop( "Cannot continue" )
   }
   stats::setNames(res, files.relative)
 

--- a/R/deploy_app.R
+++ b/R/deploy_app.R
@@ -363,8 +363,8 @@ dir_copy <- function(from, to, overwrite = TRUE, all.files = TRUE,
     # The copy failed; we should clean up after ourselves and return an error
     unlink(to, recursive = TRUE)
     message("Could not copy these files from directory '", from, "' to directory '", to, "':")
-    paste( files.from[ res==FALSE ], collate="\n" )
-    stop( "Cannot continue" )
+    message( paste( files.from[ res==FALSE ], collate="\n" ) )
+    stop( "Cannot continue." )
   }
   stats::setNames(res, files.relative)
 

--- a/R/deploy_app.R
+++ b/R/deploy_app.R
@@ -362,6 +362,9 @@ dir_copy <- function(from, to, overwrite = TRUE, all.files = TRUE,
   if (!all(res)) {
     # The copy failed; we should clean up after ourselves and return an error
     unlink(to, recursive = TRUE)
+    message( paste( files.from ) )
+    message( paste( files.to ) )
+    message( paste( res ) )
     stop("Could not copy all files from directory '", from, "' to directory '", to, "'.")
   }
   stats::setNames(res, files.relative)


### PR DESCRIPTION
I was getting errors in dir_copy() during deployment, but there was no indication of which files would not copy. I added some diagnostics to print out the files that cannot be copied. In my case, it was a file named something like .#xxxx