### PR TITLE
remove_query_string: leave the end of URL clean instead of ?

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -17,7 +17,7 @@
 remove_query_string <- function(session = shiny::getDefaultReactiveDomain(), mode = "replace") {
 
   shiny::updateQueryString(
-    "?",
+    "/",
     mode = mode,
     session = session
   )


### PR DESCRIPTION
Like queries were never provided.

I used `shiny::updateQueryString("/")` in my work and found it more convenient than having a dangling "?" with no query arguments.